### PR TITLE
Group by pool, better status lists

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,0 +1,9 @@
+
+[project]
+name = "clarity-xverse"
+
+[contracts.xverse]
+path = "contracts/xverse.clar"
+depends_on = []
+
+[notebooks]

--- a/settings/Development.toml
+++ b/settings/Development.toml
@@ -1,0 +1,42 @@
+[network]
+name = "Development"
+
+[accounts.deployer]
+mnemonic = "fetch outside black test wash cover just actual execute nice door want airport betray quantum stamp fish act pen trust portion fatigue scissors vague"
+balance = 1_000_000
+
+[accounts.wallet_1]
+mnemonic = "spoil sock coyote include verify comic jacket gain beauty tank flush victory illness edge reveal shallow plug hobby usual juice harsh pact wreck eight"
+balance = 1_000_000
+
+[accounts.wallet_2]
+mnemonic = "arrange scale orient half ugly kid bike twin magnet joke hurt fiber ethics super receive version wreck media fluid much abstract reward street alter"
+balance = 1_000_000
+
+[accounts.wallet_3]
+mnemonic = "glide clown kitchen picnic basket hidden asset beyond kid plug carbon talent drama wet pet rhythm hero nest purity baby bicycle ghost sponsor dragon"
+balance = 1_000_000
+
+[accounts.wallet_4]
+mnemonic = "pulp when detect fun unaware reduce promote tank success lecture cool cheese object amazing hunt plug wing month hello tunnel detect connect floor brush"
+balance = 1_000_000
+
+[accounts.wallet_5]
+mnemonic = "replace swing shove congress smoke banana tired term blanket nominee leave club myself swing egg virus answer bulk useful start decrease family energy february"
+balance = 1_000_000
+
+[accounts.wallet_6]
+mnemonic = "apology together shy taxi glare struggle hip camp engage lion possible during squeeze hen exotic marriage misery kiwi once quiz enough exhibit immense tooth"
+balance = 1_000_000
+
+[accounts.wallet_7]
+mnemonic = "antenna bitter find rely gadget father exact excuse cross easy elbow alcohol injury loud silk bird crime cabbage winter fit wide screen update october"
+balance = 1_000_000
+
+[accounts.wallet_8]
+mnemonic = "east load echo merit ignore hip tag obvious truly adjust smart panther deer aisle north hotel process frown lock property catch bless notice topple"
+balance = 1_000_000
+
+[accounts.wallet_9]
+mnemonic = "market ocean tortoise venue vivid coach machine category conduct enable insect jump fog file test core book chaos crucial burst version curious prosper fever"
+balance = 1_000_000

--- a/settings/Mocknet.toml
+++ b/settings/Mocknet.toml
@@ -1,0 +1,6 @@
+[network]
+name = "mocknet"
+node_rpc_address = "http://localhost:20443"
+
+[accounts.deployer]
+mnemonic = "point approve language letter cargo rough similar wrap focus edge polar task olympic tobacco cinnamon drop lawn boring sort trade senior screen tiger climb"

--- a/tests/xverse_test.ts
+++ b/tests/xverse_test.ts
@@ -1,0 +1,49 @@
+import {
+  Clarinet,
+  Tx,
+  Chain,
+  Account,
+  types,
+} from "https://deno.land/x/clarinet@v0.6.0/index.ts";
+import { assertEquals } from "https://deno.land/std@0.90.0/testing/asserts.ts";
+
+Clarinet.test({
+  name: "Ensure that users can delegate",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let wallet_1 = accounts.get("wallet_1")!;
+    let deployer = accounts.get("deployer")!;
+
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "ST000000000000000000002AMW42H.pox",
+        "allow-contract-caller",
+        [
+          types.principal(deployer.address + ".xverse"),
+          types.none(),
+        ],
+        wallet_1.address
+      ),
+
+      Tx.contractCall(
+        "xverse",
+        "delegate-stx",
+        [
+          types.uint(1000000),
+          types.principal(deployer.address),
+          types.some(types.uint(100)),
+          types.none(),
+          types.tuple({version: "0x01", hashbytes: "0x123456"}),
+          types.uint(2),
+        ],
+        wallet_1.address
+      ),
+    ]);
+    assertEquals(block.receipts.length, 2);
+    assertEquals(block.receipts[0].result, "(err 9)");
+
+    // permission denied
+    assertEquals(block.receipts[1].result, "(err u9000)");
+    assertEquals(block.height, 2);
+
+  },
+});


### PR DESCRIPTION
This PR
* adds the pool as an key to the data maps to allow more than one pool admin to use the contract
* groups the status list by lock-period
* adjusts the error types to comply with `SP1K1A1PMGW2ZJCNF46NWZWHG8TS1D23EGH1KNK60.pool-registry-v1.pox-trait-ext`
* removes the minimum amount required for delegation because users can set higher amounts than they have
* renames `stackers-by-start-cycle` -> `grouped-stackers`
* renames `totals-by-start-cycle` -> `grouped-totals`
* adds clarinet config